### PR TITLE
fix: add missing shell command

### DIFF
--- a/common-issues/invalid-ssl.md
+++ b/common-issues/invalid-ssl.md
@@ -15,3 +15,6 @@ To resolve this issue and regenerate the SSL certificates:
 1. Go to your 5Stack installation directory.
 2. Run `git pull` to ensure you have the latest updates.
 3. Regenerate the certificates by running:
+   ```sh
+   ./fix-ssl.sh
+   ```


### PR DESCRIPTION
User should be able to copy the command to regenerate SSL certificates