### PR TITLE
chore: add grub info to lowlatency setup

### DIFF
--- a/servers/low-latency-kernel.md
+++ b/servers/low-latency-kernel.md
@@ -55,6 +55,10 @@ This guide provides instructions for installing the low-latency kernel on Ubuntu
 
    The output should show "lowlatency" in the kernel version.
 
+:::info
+If the kernel does not yet show "lowlatency", the new kernel might have to be selected for boot first. One way to do this is [GrubReboot](https://wiki.debian.org/GrubReboot). Example: `grub-reboot '1>4'`, where the numbers depend on the grub menu items of your system as explained in the link.
+:::
+
 ## Kernel Parameter Optimization
 
 After installing the low-latency kernel, you'll want to optimize several kernel parameters for better performance:


### PR DESCRIPTION
Not sure if the wording is accurate, but I needed to do that step again on our server with Ubuntu 24 so I thought it's worth mentioning in the docs. Kudos to the user [windowsxp on discord](https://discord.com/channels/1281358220035887195/1370193541493690520/1473083337286353009) for the hint!

Also, since revisiting that conversation the comment about the provider restricting grub reminded me of the warning when i used `grub-reboot`:

> WARNING: Detected GRUB environment block on diskfilter device
1>4 will remain the default boot entry until manually cleared with:
    grub-editenv /boot/grub/grubenv unset next_entry